### PR TITLE
Fix AICA ADPCM Sample Decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,20 @@ LD   = $(CC)
 CFLAGS += -c -DPATH_MAX=1024 -DHAS_PSXCPU=1 -I. -I.. -Ieng_ssf -Ieng_qsf  -Ieng_dsf -Izlib -fdata-sections -ffunction-sections
 # set for little-endian, make "0" for big-endian
 CFLAGS += -DLSB_FIRST=1
-LDFLAGS += -Wl,--gc-sections
+
+ifeq ($(OS),Windows_NT)
+	#Windows
+	LDFLAGS += -Wl,--gc-sections
+else
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Darwin)
+		#macOS
+        LDFLAGS += -Wl,-dead_strip
+	else
+		#Linux
+		LDFLAGS += -Wl,--gc-sections
+    endif
+endif
 
 MACHINE = $(shell $(CC) -dumpmachine)
 

--- a/eng_dsf/aica.c
+++ b/eng_dsf/aica.c
@@ -318,7 +318,7 @@ INLINE signed short DecodeADPCM(struct _ADPCM_STATE *adpcm, unsigned char Delta)
 {
 	int x = adpcm->cur_quant * quant_mul [Delta & 15];
 	x = adpcm->cur_sample + ((int)(x + ((UINT32)x >> 29)) >> 3);
-	adpcm->cur_sample=ICLIP16(x);
+	adpcm->cur_sample=ICLIP16(x) * 254 / 256;
 	adpcm->cur_quant=(adpcm->cur_quant*TableQuant[Delta&7])>>ADPCMSHIFT;
 	adpcm->cur_quant=(adpcm->cur_quant<0x7f)?0x7f:((adpcm->cur_quant>0x6000)?0x6000:adpcm->cur_quant);
 	return adpcm->cur_sample;

--- a/eng_psf/peops/spu.c
+++ b/eng_psf/peops/spu.c
@@ -84,6 +84,7 @@
 #include "../peops/regs.h"
 #include "../peops/registers.h"
 #include "../peops/spu.h"
+#include "../../corlett.h"
 
 void SPUirq(void) ;
 

--- a/eng_psf/peops2/spu.c
+++ b/eng_psf/peops2/spu.c
@@ -102,6 +102,7 @@
 #include "../peops2/externals.h"
 #include "../peops2/regs.h"
 #include "../peops2/dma.h"
+#include "../../corlett.h"
 
 ////////////////////////////////////////////////////////////////////////
 // globals


### PR DESCRIPTION
The ADPCM decoder in AOSDK does not handle loud samples correctly, causing some tracks to sound incorrect.
For example, try 0002_020.dsf from the Shenmue II DSF rip.

Pictured below are the waveforms for two of the instrument samples in this song. First waveform is the current code decoding them. You can clearly see the waveform is not centered. Depending on the samples being tested, this can cause them to sound increasingly worse the longer the originals were close to clipping. The second waveform is properly centered. The 3rd and 4th are another example from that track.

<img width="1470" alt="Screen Shot 2020-12-28 at 3 59 25 PM" src="https://user-images.githubusercontent.com/1350664/103245595-462ef700-4926-11eb-9647-6fddc9d359bb.png">

This bug was actually reported to me in September 2019 in a separate utility I wrote to convert AICA ADPCM to WAV, but I had based decoding on the same logic used here.
https://github.com/Sappharad/AicaADPCM2WAV/
This project has the same bug I fixed there, and thus I'm contributing the fix back to you. The person who reported the bug to me initially found some code that worked properly, and although it was implemented very differently after analyzing it I realized the only difference was the clamping for loud values and I was able to incorporate it to get the desired results.