### PR TITLE
Link to opengl32.lib on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ LIBS += -ldsound -ldxguid
 # Windows DLLs referenced by win32_utf8, which are hopefully eliminated by
 # -gc-sections one day…
 LIBS += -lcomdlg32 -lgdi32 -lole32 -lpsapi -lshlwapi -lversion -lwininet
+ifndef NOGUI
+# Windows OpenGL DLL, referenced by ImGui
+LIBS += -lopengl32
+endif
 endif
 
 # DSF engine


### PR DESCRIPTION
When building with MSYS2 I was getting link errors for undefined `__imp_glViewport` etc. This patch explicitly links to opengl32, I think I found the right place in the Makefile to put this just for Windows.